### PR TITLE
Set up with Deploy to Cloudflare Workers button

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,12 +54,25 @@ jobs:
       - run: npm ci && cd workers-site && npm ci
 
       - name: Publish
-        # only publish if a direct `push`/`repository_dispatch`
         uses: cloudflare/wrangler-action@1.2.0
-        if: github.event_name == 'repository_dispatch' || github.event_name == 'push'
+        # only publish if a direct `push`/`repository_dispatch`
+        # publish non-production deploy if it's a fork
+        if: github.event_name == 'repository_dispatch' || github.event_name == 'push' && github.repository_owner != 'Cherry'
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+
+      - name: Publish (production)
+        uses: cloudflare/wrangler-action@1.2.0
+        # only publish if a direct `push`/`repository_dispatch`
+        # publish production deploy if it's the original repository
+        if: github.event_name == 'repository_dispatch' || github.event_name == 'push' && github.repository_owner == 'Cherry'
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           environment: 'production'
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
 
       # these folders have secrets/configs in them that prevent the cache from running successfully
       # TODO: remove when https://github.com/actions/cache/issues/133 has a solution

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Generate super-fast placeholder images in 200+ edge locations, powered by Cloudf
 ![350x150 placeholder image](https://images.placeholders.dev/?width=350&amp;height=100)![200x100 placeholder image](https://images.placeholders.dev/?width=200&amp;height=100&amp;bgColor=%23000&amp;textColor=rgba(255,255,255,0.5))![140x100 placeholder image](https://images.placeholders.dev/?width=140&amp;height=100&amp;bgColor=%23313131&amp;textColor=%23dfdfde)
 ![1055x100 placeholder image](https://images.placeholders.dev/?width=1055&amp;height=100&amp;text=Hello%20World&amp;bgColor=%23434343&amp;textColor=%23dfdfde)
 
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/signalnerve/placeholders.dev)
 
 ## Info
 


### PR DESCRIPTION
Hey @cherry! We're working on a [deploy tool](https://deploy.workers.cloudflare.com) for Cloudflare Workers apps, and we really want to include this project in the list of cool stuff to deploy!

This adds a missing piece in the deploy workflow to get it working with the tool — specifically, passing in a `CF_ACCOUNT_ID` env var based on the `CF_ACCOUNT_ID` secret, which will be set by the deploy tool.

It should pass through transparently if that secret isn't set, so it'll deploy for you as it has in the past, but for anyone that forks and provides their own secret there, it'll deploy to their account 👍