### PR TITLE
fix: Update number of locations everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # [placeholders.dev](https://placeholders.dev)
-Generate super-fast placeholder images in 270+ edge locations, powered by Cloudflare Workers
+Generate super-fast placeholder images in 330+ edge locations, powered by Cloudflare Workers
 ![350x150 placeholder image](https://images.placeholders.dev/?width=350&amp;height=100)![200x100 placeholder image](https://images.placeholders.dev/?width=200&amp;height=100&amp;bgColor=%23000&amp;textColor=rgba(255,255,255,0.5))![140x100 placeholder image](https://images.placeholders.dev/?width=140&amp;height=100&amp;bgColor=%23313131&amp;textColor=%23dfdfde)
 ![1055x100 placeholder image](https://images.placeholders.dev/?width=1055&amp;height=100&amp;text=Hello%20World&amp;bgColor=%23434343&amp;textColor=%23dfdfde)
 
@@ -7,7 +7,7 @@ Generate super-fast placeholder images in 270+ edge locations, powered by Cloudf
 
 ## Info
 
-placeholders.dev generates custom placeholder images on the fly, such as the examples above. All of these images are generated on Cloudflare's Edge, at 200+ locations, ensuring the best possible performance for all of your users. All images are cached for lengthy periods of time.
+placeholders.dev generates custom placeholder images on the fly, such as the examples above. All of these images are generated on Cloudflare's Edge, at 330+ locations, ensuring the best possible performance for all of your users. All images are cached for lengthy periods of time.
 
 ## Technology
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "placeholders.dev",
 	"version": "1.0.0",
-	"description": "Generate placeholder images with Cloudflare Workers in 200+ edge locations",
+	"description": "Generate placeholder images with Cloudflare Workers in 330+ edge locations",
 	"keywords": [
 		"placeholders"
 	],

--- a/public/404.html
+++ b/public/404.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>placeholders.dev</title>
-	<meta name="description" content="Generate super fast placeholder images powered by Cloudflare Workers in 200+ edge locations.">
+	<meta name="description" content="Generate super fast placeholder images powered by Cloudflare Workers in 330+ edge locations.">
 	<meta name="rating" content="General">
 	<meta name="twitter:creator" content="@cherryjimbo">
 	<meta name="copyright" content="James Ross">

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>placeholders.dev - Super fast image placeholders</title>
-	<meta name="description" content="Generate super fast placeholder images powered by Cloudflare Workers in 200+ edge locations.">
+	<meta name="description" content="Generate super fast placeholder images powered by Cloudflare Workers in 330+ edge locations.">
 	<meta name="rating" content="General">
 
 	<meta property="og:url" content="https://placeholders.dev">
@@ -14,7 +14,7 @@
 	<meta property="og:image:alt" content="placeholders.dev">
 	<meta property="og:image:width" content="1200">
 	<meta property="og:image:height" content="600">
-	<meta property="og:description" content="Generate super fast placeholder images powered by Cloudflare Workers in 270+ edge locations.">
+	<meta property="og:description" content="Generate super fast placeholder images powered by Cloudflare Workers in 330+ edge locations.">
 	<meta property="og:site_name" content="placeholders.dev">
 	<meta property="og:locale" content="en_US">
 
@@ -22,7 +22,7 @@
 	<meta name="twitter:creator" content="@cherryjimbo">
 	<meta name="twitter:url" content="https://placeholders.dev">
 	<meta name="twitter:title" content="placeholders.dev">
-	<meta name="twitter:description" content="Generate super fast placeholder images powered by Cloudflare Workers in 270+ edge locations.">
+	<meta name="twitter:description" content="Generate super fast placeholder images powered by Cloudflare Workers in 330+ edge locations.">
 	<meta name="twitter:image" content="https://placeholders.dev/share.png">
 	<meta name="twitter:image:alt" content="placeholders.dev">
 
@@ -186,7 +186,7 @@
 	<!-- Based on https://github.com/flexdinesh/dev-landing-page. MIT License -->
 	<main>
 		<div class="intro">placeholders.dev</div>
-		<h1 class="tagline">Generate super-fast placeholder images in <span class="edgeLocations">270</span>+ edge locations, powered by Cloudflare Workers</h1>
+		<h1 class="tagline">Generate super-fast placeholder images in <span class="edgeLocations">330</span>+ edge locations, powered by Cloudflare Workers</h1>
 		<div class="examples">
 			<img src="https://images.placeholders.dev/?width=350&height=100" width="350" height="150" alt="350x150 placeholder image">
 			<img src="https://images.placeholders.dev/?width=200&height=100&bgColor=%23000&textColor=rgba(255,255,255,0.5)" width="200" height="100" alt="200x100 placeholder image">
@@ -196,7 +196,7 @@
 		</div>
 		<div class="documentation">
 			<h2>Information</h2>
-			<p>placeholders.dev generates custom placeholder images on the fly, such as the examples above. All of these images are generated on Cloudflare's Edge, at <span class="edgeLocations">200</span>+ locations, ensuring the best possible performance for all of your users. All images are cached for lengthy periods of time.</p>
+			<p>placeholders.dev generates custom placeholder images on the fly, such as the examples above. All of these images are generated on Cloudflare's Edge, at <span class="edgeLocations">330</span>+ locations, ensuring the best possible performance for all of your users. All images are cached for lengthy periods of time.</p>
 
 			<h3>Available API Options</h3>
 			<dl>


### PR DESCRIPTION
According to Cloudflare's recent blog posts (eg. https://blog.cloudflare.com/container-platform-preview/), they now have 330+ locations.

Fortunately, because of the auto-updating script, the incredibly stale values of 200 and 270 were only visible in some places.