### PR TITLE
fix: use up to date wrangler version in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,6 @@ on:
 
 env:
   NODE_VERSION: 22.x
-  WRANGLER_VERSION: 3.99.0
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -41,7 +40,7 @@ jobs:
       - run: npm ci
 
       - name: Publish
-        uses: cloudflare/wrangler-action@v3.13.0
+        uses: cloudflare/wrangler-action@v3.14.0
         # only publish if a direct `push`/`repository_dispatch`
         # publish non-production deploy if it's a fork
         if: github.event_name == 'repository_dispatch' || github.event_name == 'push' && github.repository_owner != 'Cherry'
@@ -49,10 +48,9 @@ jobs:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           command: "deploy"
-          wranglerVersion: ${{ env.WRANGLER_VERSION }}
 
       - name: Publish (production)
-        uses: cloudflare/wrangler-action@v3.13.0
+        uses: cloudflare/wrangler-action@v3.14.0
         # only publish if a direct `push`/`repository_dispatch`
         # publish production deploy if it's the original repository
         if: (github.event_name == 'repository_dispatch' || github.event_name == 'push') && github.repository_owner == 'Cherry'
@@ -60,5 +58,4 @@ jobs:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           command: "deploy --env=production"
-          wranglerVersion: ${{ env.WRANGLER_VERSION }}
 


### PR DESCRIPTION
By not specifying one, this will pull from package.json

Fixes #46 