### PR TITLE
chore: disable wrangler telemetry

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,6 @@
 name = "placeholders-dev"
 workers_dev = true
+send_metrics = false
 compatibility_date = "2023-12-09"
 compatibility_flags = ["nodejs_compat"]
 main = "./src/index.ts"


### PR DESCRIPTION
wrangler is starting to add telemetry that is concerning. In an abundance of caution and to protect user privacy for any contributors, we're disabling all telemetry for Cloudflare wrangler. 

See my concerns at https://github.com/cloudflare/workers-sdk/pull/12708#issuecomment-3988585895 for details.